### PR TITLE
Transform matrix

### DIFF
--- a/librestreaming/src/main/java/me/lake/librestreaming/client/RESVideoClient.java
+++ b/librestreaming/src/main/java/me/lake/librestreaming/client/RESVideoClient.java
@@ -91,6 +91,7 @@ public class RESVideoClient {
     private Camera createCamera(int cameraId) {
         try {
             camera = Camera.open(cameraId);
+            camera.setDisplayOrientation(0);
         } catch (SecurityException e) {
             LogTools.trace("no permission", e);
             return null;

--- a/librestreaming/src/main/java/me/lake/librestreaming/core/GLHelper.java
+++ b/librestreaming/src/main/java/me/lake/librestreaming/core/GLHelper.java
@@ -82,25 +82,25 @@ public class GLHelper {
             1.0f, 0.0f,
             1.0f, 1.0f};
     private static float Cam2dTextureVertices[] = {
-            0.0f, 0.0f,
             0.0f, 1.0f,
-            1.0f, 1.0f,
-            1.0f, 0.0f};
-    private static float Cam2dTextureVertices_90[] = {
-            0.0f, 1.0f,
-            1.0f, 1.0f,
-            1.0f, 0.0f,
-            0.0f, 0.0f};
-    private static float Cam2dTextureVertices_180[] = {
-            1.0f, 1.0f,
-            1.0f, 0.0f,
             0.0f, 0.0f,
-            0.0f, 1.0f};
-    private static float Cam2dTextureVertices_270[] = {
             1.0f, 0.0f,
-            0.0f, 0.0f,
-            0.0f, 1.0f,
             1.0f, 1.0f};
+    private static float Cam2dTextureVertices_90[] = {
+            0.0f, 0.0f,
+            1.0f, 0.0f,
+            1.0f, 1.0f,
+            0.0f, 1.0f};
+    private static float Cam2dTextureVertices_180[] = {
+            1.0f, 0.0f,
+            1.0f, 1.0f,
+            0.0f, 1.0f,
+            0.0f, 0.0f};
+    private static float Cam2dTextureVertices_270[] = {
+            1.0f, 1.0f,
+            0.0f, 1.0f,
+            0.0f, 0.0f,
+            1.0f, 0.0f};
     private static float MediaCodecTextureVertices[] = {
             0.0f, 1.0f,
             0.0f, 0.0f,

--- a/librestreaming/src/main/java/me/lake/librestreaming/core/GLHelper.java
+++ b/librestreaming/src/main/java/me/lake/librestreaming/core/GLHelper.java
@@ -35,6 +35,15 @@ public class GLHelper {
             "    gl_Position= aPosition;\n" +
             "    vTextureCoord = aTextureCoord;\n" +
             "}";
+    private static final String VERTEXSHADER_CAMERA2D =
+            "attribute vec4 aPosition;\n" +
+            "attribute vec4 aTextureCoord;\n" +
+            "uniform mat4 uTextureMatrix;\n" +
+            "varying vec2 vTextureCoord;\n" +
+            "void main(){\n" +
+            "    gl_Position= aPosition;\n" +
+            "    vTextureCoord = (uTextureMatrix * aTextureCoord).xy;\n" +
+            "}";
     private static String FRAGMENTSHADER_CAMERA = "" +
             "#extension GL_OES_EGL_image_external : require\n" +
             "precision mediump float;\n" +
@@ -297,7 +306,7 @@ public class GLHelper {
     }
 
     public static int createCamera2DProgram() {
-        return GLESTools.createProgram(VERTEXSHADER, FRAGMENTSHADER_CAMERA2D);
+        return GLESTools.createProgram(VERTEXSHADER_CAMERA2D, FRAGMENTSHADER_CAMERA2D);
     }
 
     public static int createCameraProgram() {

--- a/librestreaming/src/main/java/me/lake/librestreaming/core/RESHardVideoCore.java
+++ b/librestreaming/src/main/java/me/lake/librestreaming/core/RESHardVideoCore.java
@@ -762,7 +762,7 @@ public class RESHardVideoCore implements RESVideoCore {
             synchronized (syncCameraTextureVerticesBuffer) {
                 currCamera = cameraIndex;
                 if (currCamera == Camera.CameraInfo.CAMERA_FACING_FRONT) {
-                    directionFlag = resCoreParameters.frontCameraDirectionMode;
+                    directionFlag = resCoreParameters.frontCameraDirectionMode ^ RESConfig.DirectionMode.FLAG_DIRECTION_FLIP_HORIZONTAL;
                 } else {
                     directionFlag = resCoreParameters.backCameraDirectionMode;
                 }

--- a/librestreaming/src/main/java/me/lake/librestreaming/core/RESHardVideoCore.java
+++ b/librestreaming/src/main/java/me/lake/librestreaming/core/RESHardVideoCore.java
@@ -340,7 +340,7 @@ public class RESHardVideoCore implements RESVideoCore {
                             }
                         }
                     }
-                    drawSample2DFrameBuffer();
+                    drawSample2DFrameBuffer(cameraTexture);
                 }
                 break;
                 case WHAT_DRAW: {
@@ -467,7 +467,7 @@ public class RESHardVideoCore implements RESVideoCore {
         }
 
 
-        private void drawSample2DFrameBuffer() {
+        private void drawSample2DFrameBuffer(SurfaceTexture cameraTexture) {
             GLES20.glBindFramebuffer(GLES20.GL_FRAMEBUFFER, sample2DFrameBuffer);
             GLES20.glUseProgram(offScreenGLWapper.cam2dProgram);
             GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
@@ -477,6 +477,9 @@ public class RESHardVideoCore implements RESVideoCore {
                 GLHelper.enableVertex(offScreenGLWapper.cam2dPostionLoc, offScreenGLWapper.cam2dTextureCoordLoc,
                         shapeVerticesBuffer, camera2dTextureVerticesBuffer);
             }
+            float[] textureMatrix = new float[16];
+            cameraTexture.getTransformMatrix(textureMatrix);
+            GLES20.glUniformMatrix4fv(offScreenGLWapper.cam2dTextureMatrix, 1, false, textureMatrix, 0);
             GLES20.glViewport(0, 0, resCoreParameters.videoWidth, resCoreParameters.videoHeight);
             doGLDraw();
             GLES20.glFinish();
@@ -640,6 +643,7 @@ public class RESHardVideoCore implements RESVideoCore {
                 offScreenGLWapper.cam2dTextureLoc = GLES20.glGetUniformLocation(offScreenGLWapper.cam2dProgram, "uTexture");
                 offScreenGLWapper.cam2dPostionLoc = GLES20.glGetAttribLocation(offScreenGLWapper.cam2dProgram, "aPosition");
                 offScreenGLWapper.cam2dTextureCoordLoc = GLES20.glGetAttribLocation(offScreenGLWapper.cam2dProgram, "aTextureCoord");
+                offScreenGLWapper.cam2dTextureMatrix = GLES20.glGetUniformLocation(offScreenGLWapper.cam2dProgram, "uTextureMatrix");
                 int[] fb = new int[1], fbt = new int[1];
                 GLHelper.createCamFrameBuff(fb, fbt, resCoreParameters.videoWidth, resCoreParameters.videoHeight);
                 sample2DFrameBuffer = fb[0];

--- a/librestreaming/src/main/java/me/lake/librestreaming/model/OffScreenGLWapper.java
+++ b/librestreaming/src/main/java/me/lake/librestreaming/model/OffScreenGLWapper.java
@@ -16,6 +16,7 @@ public class OffScreenGLWapper {
     public EGLContext eglContext;
 
     public int cam2dProgram;
+    public int cam2dTextureMatrix;
     public int cam2dTextureLoc;
     public int cam2dPostionLoc;
     public int cam2dTextureCoordLoc;

--- a/sample/src/main/java/me/lake/librestreaming/sample/BaseStreamingActivity.java
+++ b/sample/src/main/java/me/lake/librestreaming/sample/BaseStreamingActivity.java
@@ -95,10 +95,10 @@ public class BaseStreamingActivity extends AppCompatActivity implements RESConne
         Camera.getCameraInfo(Camera.CameraInfo.CAMERA_FACING_BACK, cameraInfo);
         backDirection = cameraInfo.orientation;
         if (this.getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT) {
-            resConfig.setFrontCameraDirectionMode((frontDirection == 90 ? RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_270 : RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_90) | RESConfig.DirectionMode.FLAG_DIRECTION_FLIP_VERTICAL);
-            resConfig.setBackCameraDirectionMode((backDirection == 90 ? RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_90 : RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_270) | RESConfig.DirectionMode.FLAG_DIRECTION_FLIP_VERTICAL);
+            resConfig.setFrontCameraDirectionMode((frontDirection == 90 ? RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_270 : RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_90) | RESConfig.DirectionMode.FLAG_DIRECTION_FLIP_HORIZONTAL);
+            resConfig.setBackCameraDirectionMode((backDirection == 90 ? RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_90 : RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_270));
         } else {
-            resConfig.setBackCameraDirectionMode((backDirection == 90 ? RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_0 : RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_180) | RESConfig.DirectionMode.FLAG_DIRECTION_FLIP_VERTICAL);
+            resConfig.setBackCameraDirectionMode((backDirection == 90 ? RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_0 : RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_180));
             resConfig.setFrontCameraDirectionMode((frontDirection == 90 ? RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_180 : RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_0) | RESConfig.DirectionMode.FLAG_DIRECTION_FLIP_HORIZONTAL);
         }
         resConfig.setRtmpAddr(rtmpaddr);

--- a/sample/src/main/java/me/lake/librestreaming/sample/BaseStreamingActivity.java
+++ b/sample/src/main/java/me/lake/librestreaming/sample/BaseStreamingActivity.java
@@ -95,10 +95,10 @@ public class BaseStreamingActivity extends AppCompatActivity implements RESConne
         Camera.getCameraInfo(Camera.CameraInfo.CAMERA_FACING_BACK, cameraInfo);
         backDirection = cameraInfo.orientation;
         if (this.getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT) {
-            resConfig.setFrontCameraDirectionMode((frontDirection == 90 ? RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_270 : RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_90) | RESConfig.DirectionMode.FLAG_DIRECTION_FLIP_HORIZONTAL);
-            resConfig.setBackCameraDirectionMode((backDirection == 90 ? RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_90 : RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_270));
+            resConfig.setFrontCameraDirectionMode((frontDirection == 90 ? RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_270 : RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_90) | RESConfig.DirectionMode.FLAG_DIRECTION_FLIP_VERTICAL);
+            resConfig.setBackCameraDirectionMode((backDirection == 90 ? RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_90 : RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_270) | RESConfig.DirectionMode.FLAG_DIRECTION_FLIP_VERTICAL);
         } else {
-            resConfig.setBackCameraDirectionMode((backDirection == 90 ? RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_0 : RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_180));
+            resConfig.setBackCameraDirectionMode((backDirection == 90 ? RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_0 : RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_180) | RESConfig.DirectionMode.FLAG_DIRECTION_FLIP_VERTICAL);
             resConfig.setFrontCameraDirectionMode((frontDirection == 90 ? RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_180 : RESConfig.DirectionMode.FLAG_DIRECTION_ROATATION_0) | RESConfig.DirectionMode.FLAG_DIRECTION_FLIP_HORIZONTAL);
         }
         resConfig.setRtmpAddr(rtmpaddr);


### PR DESCRIPTION
Fix this [issue](https://github.com/lakeinchina/librestreaming/issues/160).
[setDisplayOrientation()](https://developer.android.com/reference/android/hardware/Camera.html#setDisplayOrientation(int)) will influence the return array of [getTransformMatrix()](https://developer.android.com/reference/android/graphics/SurfaceTexture.html#getTransformMatrix(float[])). The default value of some specific devices like Nexus6 is different from most devices, so I set this to 0.
[Doc of setDisplayOrientation](https://developer.android.com/reference/android/hardware/Camera.html#setDisplayOrientation(int)) mentions that **preview display of front-facing cameras is flipped horizontally**, so the front-facing camera don't need to flip horizontally again. So I cancel the flip and adjust the camera2d texture coordinate.
