### PR TITLE
解决64位时调用close崩溃问题

### DIFF
--- a/librestreaming/src/main/jni/rtmp/libresrtmp.c
+++ b/librestreaming/src/main/jni/rtmp/libresrtmp.c
@@ -125,7 +125,7 @@
  * Signature: ()I
  */
  JNIEXPORT jint JNICALL Java_me_lake_librestreaming_rtmp_RtmpClient_close
- (JNIEnv * env,jlong rtmp, jobject thiz) {
+ (JNIEnv * env, jobject thiz, jlong rtmp) {
  	RTMP_Close((RTMP*)rtmp);
  	RTMP_Free((RTMP*)rtmp);
  	return 0;


### PR DESCRIPTION
我碰到了在编译64位时调用close时崩溃的问题， 定位到是指针发生错误， 其原因是参数错误， 将其更改后，测试不崩溃。